### PR TITLE
Optim: preproc_grad callable, _grads, _grads_postproc for diagnostics

### DIFF
--- a/higher/optim.py
+++ b/higher/optim.py
@@ -121,6 +121,7 @@ class DifferentiableOptimizer(_abc.ABC):
 
         self._fmodel = fmodel
         self._track_higher_grads = track_higher_grads
+        self._grads = None
 
     def _apply_override(self, override: _OverrideType) -> None:
         for k, v in override.items():
@@ -256,6 +257,7 @@ class DifferentiableSGD(DifferentiableOptimizer):
             dampening = group['dampening']
             nesterov = group['nesterov']
 
+            self._grads = []
             for p_idx, (p, g) in enumerate(zip(group['params'], grads)):
                 if g is None:
                     continue
@@ -276,6 +278,8 @@ class DifferentiableSGD(DifferentiableOptimizer):
                         g = buf
 
                 group['params'][p_idx] = _add(p, -group['lr'], g)
+                self._grads.append(g)
+
 
 
 class DifferentiableAdam(DifferentiableOptimizer):

--- a/higher/optim.py
+++ b/higher/optim.py
@@ -121,7 +121,7 @@ class DifferentiableOptimizer(_abc.ABC):
 
         self._fmodel = fmodel
         self._track_higher_grads = track_higher_grads
-        self._grads, self._grads_postproc = None, None
+        self._grads, self._grads_postproc, self._grads_preproc = None, None, None
 
     def _apply_override(self, override: _OverrideType) -> None:
         for k, v in override.items():
@@ -213,6 +213,8 @@ class DifferentiableOptimizer(_abc.ABC):
             create_graph=self._track_higher_grads,
             allow_unused=True  # boo
         )
+
+        self._grads_preproc = [grad.clone() for grad in all_grads]
 
         grouped_grads = []
         for group, mapping in zip(self.param_groups, self._group_to_param_list):

--- a/higher/optim.py
+++ b/higher/optim.py
@@ -139,6 +139,7 @@ class DifferentiableOptimizer(_abc.ABC):
         loss: _torch.Tensor,
         params: _typing.Iterable[_torch.Tensor] = None,
         override: _typing.Optional[_OverrideType] = None,
+        preproc_grad: _typing.Callable[[list], list] = None,
         **kwargs
     ) -> _typing.Iterable[_torch.Tensor]:
         r"""Perform a model update.
@@ -220,6 +221,8 @@ class DifferentiableOptimizer(_abc.ABC):
                 grads.append(all_grads[index])
             grouped_grads.append(grads)
 
+        if preproc_grad is not None: 
+            for g_group in grouped_grads: preproc_grad(g_group)
         self._update(grouped_grads)
 
         new_params = params[:]

--- a/higher/optim.py
+++ b/higher/optim.py
@@ -282,7 +282,6 @@ class DifferentiableSGD(DifferentiableOptimizer):
                 self._grads_postproc.append(g_postproc)
 
 
-
 class DifferentiableAdam(DifferentiableOptimizer):
     r"""A differentiable version of the Adam optimizer.
 
@@ -297,7 +296,6 @@ class DifferentiableAdam(DifferentiableOptimizer):
             beta1, beta2 = group['betas']
             weight_decay = group['weight_decay']
 
-            self._grads = []
             for p_idx, (p, g) in enumerate(zip(group['params'], grads)):
 
                 if g is None:


### PR DESCRIPTION
- Added preproc_grad as a callable for preprocessing gradients in diff optimizers
- Added _grads and _grads_postproc for diagnostics purposes
- Added _add_, _addcdiv_, _addcmul_ that output a tuple containing the results of the corresponding ops and the added term to the original vector. This way I avoid changing interface of the original functions (i.e. _add, _addcdiv, _addcmul stay the same)