### PR TITLE
Add patched RNN forward and meta-gradient units

### DIFF
--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -122,8 +122,8 @@ class TestPatch(unittest.TestCase):
         fmodel = higher.patch.monkeypatch(model)
         for _ in range(10):
             inputs = torch.rand(8, 4)
-            ref_loss = model(inputs).pow(2).sum()
-            loss = fmodel(inputs).pow(2).sum()
+            ref_loss = model(inputs).sum().pow(2)
+            loss = fmodel(inputs).sum().pow(2)
             ref_loss.backward()
             loss.backward()
             for true_param, got_param in zip(
@@ -144,7 +144,7 @@ class TestPatch(unittest.TestCase):
         fmodel = higher.patch.monkeypatch(model)
         for _ in range(10):
             inputs = torch.rand(8, 4)
-            loss = fmodel(inputs).pow(2).sum()
+            loss = fmodel(inputs).sum().pow(2)
             grads = torch.autograd.grad(
                 loss, fmodel.parameters(), allow_unused=True, create_graph=True
             )
@@ -165,7 +165,7 @@ class TestPatch(unittest.TestCase):
         with higher.innerloop_ctx(model, opt) as (fmodel, diffopt):
             for _ in range(10):
                 inputs = torch.rand(8, 4)
-                loss = fmodel(inputs).pow(2).sum()
+                loss = fmodel(inputs).sum().pow(2)
                 diffopt.step(loss)
             param_sum = sum(p.sum() for p in fmodel.parameters())
             final_grads = torch.autograd.grad(
@@ -249,7 +249,7 @@ class TestPatch(unittest.TestCase):
         for _ in range(10):
             inputs = torch.randn(seq_length, batch_size, num_feats)
             outputs, _ = frnn(inputs)
-            loss = outputs[-1].pow(2).sum()
+            loss = outputs[-1].sum().pow(2)
             grads = torch.autograd.grad(
                 loss, frnn.parameters(), allow_unused=True, create_graph=True
             )
@@ -284,7 +284,7 @@ class TestPatch(unittest.TestCase):
                 output = state[0]
             else:
                 output = state
-            loss = output.pow(2).sum()
+            loss = output.sum().pow(2)
             grads = torch.autograd.grad(
                 loss, fcell.parameters(), allow_unused=True, create_graph=True
             )
@@ -306,7 +306,7 @@ class TestPatch(unittest.TestCase):
         with higher.innerloop_ctx(model, opt, **ctx_opts) as (fmodel, diffopt):
             for _ in range(10):
                 inputs = torch.rand(8, 4)
-                loss = fmodel(inputs).pow(2).sum()
+                loss = fmodel(inputs).sum().pow(2)
                 diffopt.step(loss)
             param_sum = sum(p.sum() for p in fmodel.parameters())
             final_grads = torch.autograd.grad(
@@ -325,7 +325,7 @@ class TestPatch(unittest.TestCase):
         with higher.innerloop_ctx(model, opt, **ctx_opts) as (fmodel, diffopt):
             for _ in range(10):
                 inputs = torch.rand(8, 4)
-                loss = fmodel(inputs).pow(2).sum()
+                loss = fmodel(inputs).sum().pow(2)
                 diffopt.step(loss)
             param_sum = sum(p.sum() for p in fmodel.parameters())
             final_grads = torch.autograd.grad(

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -35,6 +35,12 @@ _rnn_test_sweep = [
     ("gru", nn.GRU),
 ]
 
+_rnn_cell_test_sweep = [
+    ("simple_rnn", nn.RNNCell),
+    ("lstm", nn.LSTMCell),
+    ("gru", nn.GRUCell),
+]
+
 class _NestedEnc(torch.nn.Module):
     def __init__(self, f):
         super().__init__()
@@ -183,20 +189,12 @@ class TestPatch(unittest.TestCase):
             rnn = rnn_constructor(num_feats, hidden_size, num_layers)
             frnn = higher.patch.monkeypatch(rnn)
 
-            _, dummy_next = rnn(torch.rand(1, batch_size, num_feats))
-
             for _ in range(10):
 
                 inputs = torch.randn(seq_length, batch_size, num_feats)
-                if isinstance(dummy_next, tuple):
-                    start_state = tuple(
-                        torch.randn_like(o) for o in dummy_next
-                    )
-                else:
-                    start_state = torch.randn_like(dummy_next)
 
-                output, state = rnn(inputs, start_state)
-                foutput, fstate = frnn(inputs, start_state)
+                output, state = rnn(inputs)
+                foutput, fstate = frnn(inputs)
 
                 torch.testing.assert_allclose(output, foutput)
                 if isinstance(state, tuple):


### PR DESCRIPTION
We add forward equivalence and meta-gradient existence checking for a variety of RNN and RNNCell variants.

Unrelatedly, we replaced `some_vector.pow(2).sum()` with `some_vector.sum().pow(2)` in the unit tests.