### PR TITLE
Incorporate the 'eps' hyperparameter in DifferentiableAdagrad

### DIFF
--- a/higher/optim.py
+++ b/higher/optim.py
@@ -455,7 +455,7 @@ class DifferentiableAdagrad(DifferentiableOptimizer):
                     state['sum'] = sum_ = _addcmul(state['sum'], 1, g, g)
                     mask = sum_ == 0.
                     _maybe_mask(sum_, mask)
-                    std = _add(state['sum'].sqrt(), 1e-10)
+                    std = _add(state['sum'].sqrt(), group['eps'])
                     group['params'][p_idx] = _addcdiv(p, -clr, g, std)
 
 


### PR DESCRIPTION
Hello, the `eps` hyperparameter is currently not taken into account by `DifferentiableAdagrad`. The optimiser is sometimes a bit unstable - this should help dealing with it.

Here's the PyTorch implementation: https://github.com/pytorch/pytorch/blob/master/torch/optim/adagrad.py#L99