### PR TITLE
Support calling submodules directly

### DIFF
--- a/higher/patch.py
+++ b/higher/patch.py
@@ -397,8 +397,15 @@ def make_functional(
                 "tracking its own fast parameters"
             )
 
+        # Copy fast parameters into params_box for use in boxed_forward
         params_box[0] = self._expand_params(self.fast_params)
-        return self.boxed_forward(*args, **kwargs)
+
+        output = self.boxed_forward(*args, **kwargs)
+        
+        # Clean up
+        params_box[0] = None
+        
+        return output
 
     def _update_params(self, params):
         self.fast_params = params

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -348,6 +348,23 @@ class TestPatch(unittest.TestCase):
                 self.assertIsNone(p.grad)
                 self.assertIsNone(g)
 
+    def testSubModuleDirectCall(self):
+        """Check that patched submodules can be called directly."""
+        class Module(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.submodule = nn.Linear(3, 4)
+
+            def forward(self, inputs):
+                return self.submodule(inputs)
+
+        module = _NestedEnc(nn.Linear(3, 4))
+        fmodule = higher.monkeypatch(module)
+
+        xs = torch.randn(2, 3)
+        fsubmodule = fmodule.f
+
+        self.assertTrue(torch.equal(fmodule(xs), fsubmodule(xs)))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR supports calling submodules of a patched module directly. If the *full parameter set* for the original patched module is provided to the `params` argument, they will overwrite the stored fast weights. If implicit fast weights are being used (majority of use cases), everything will work out of the box without the end user needing to do anything special.

This fixes #19. Thanks to @MichaelKonobeev for providing a minimal working example of the bug.