### PR TITLE
Fix memory leak when using `track_higher_grad=False`

### DIFF
--- a/higher/__init__.py
+++ b/higher/__init__.py
@@ -83,7 +83,10 @@ def innerloop_ctx(
         ``DifferentiableOptimizer`` instance of the right subtype.
     """
     fmodel = monkeypatch(
-        model, device, copy_initial_weights=copy_initial_weights
+        model, 
+        device, 
+        copy_initial_weights=copy_initial_weights,
+        track_higher_grads=track_higher_grads
     )
     diffopt = optim.get_diff_optim(
         opt,

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -335,13 +335,14 @@ class TestPatch(unittest.TestCase):
 
         ctx_opts = {"copy_initial_weights": False, "track_higher_grads": False}
         with higher.innerloop_ctx(model, opt, **ctx_opts) as (fmodel, diffopt):
+            init_params = fmodel.parameters(time=0)
             for _ in range(10):
                 inputs = torch.rand(8, 4)
                 loss = fmodel(inputs).sum().pow(2)
                 diffopt.step(loss)
             param_sum = sum(p.sum() for p in fmodel.parameters())
             final_grads = torch.autograd.grad(
-                param_sum, fmodel.parameters(time=0), allow_unused=True
+                param_sum, init_params, allow_unused=True
             )
             param_sum.backward()
             for p, g in zip(model.parameters(), final_grads):


### PR DESCRIPTION
Previously, as noted in #25, setting `track_higher_grad=False` did not release memory as advertised, creating a memory leak when running patched modules in "test mode" (i.e. no meta-learning). This pull request fixes this, and some surrounding issues.

Thanks to @MarisaKirisame for providing a simple bit of code to repro the error.